### PR TITLE
Enable js-cli in Cygwin environment

### DIFF
--- a/jd-cli/src/main/bin/jd-cli
+++ b/jd-cli/src/main/bin/jd-cli
@@ -3,4 +3,7 @@
 DIRNAME=$(dirname "$(readlink -e "$0")")
 DIR=$(cd "$DIRNAME" || exit 112; pwd)
 
+[ "$OSTYPE" = "cygwin" ] \
+&& DIR="$( cygpath -m "$DIR" )"
+
 java -jar "$DIR/jd-cli.jar" $@ 


### PR DESCRIPTION
The following change enables jd-cli to work properly in Cygwin environment.